### PR TITLE
Atomic storage, threadpool support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.7'
+          - '1.8'
           - '1.9'
           - '1.10.0'
           - 'nightly'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,8 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
-          - '1.8'
           - '1.9'
           - '1.10.0'
           - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,10 @@
 name = "StableTasks"
 uuid = "91464d47-22a1-43fe-8b7f-2d57ee82463f"
 authors = ["Mason Protter <mason.protter@icloud.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [compat]
-julia = "1.6"
+julia = "1.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Mason Protter <mason.protter@icloud.com>"]
 version = "0.1.3"
 
 [compat]
-julia = "1.7"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 StableTasks is a simple package with one main API `StableTasks.@spawn` (not exported by default). 
 
-It works like `Threads.@spawn`, except it is *type stable* to `fetch` from (and it does not yet support threadpools
-other than the default threadpool).
+It works like `Threads.@spawn`, except it is *type stable* to `fetch` from.
 
 ``` julia
 julia> Core.Compiler.return_type(() -> fetch(StableTasks.@spawn 1 + 1), Tuple{})

--- a/src/StableTasks.jl
+++ b/src/StableTasks.jl
@@ -3,10 +3,16 @@ module StableTasks
 macro spawn end
 macro spawnat end
 
-using Base: RefValue
-struct StableTask{T}
-    t::Task
-    ret::RefValue{T}
+mutable struct AtomicRef{T}
+    @atomic x::T
+    AtomicRef{T}() where {T} = new{T}()
+    AtomicRef(x::T) where {T} = new{T}(x)
+    AtomicRef{T}(x) where {T} = new{T}(convert(T, x))
+end
+
+mutable struct StableTask{T}
+    const t::Task
+    ret::AtomicRef{T}
 end
 
 include("internals.jl")

--- a/src/StableTasks.jl
+++ b/src/StableTasks.jl
@@ -10,8 +10,8 @@ mutable struct AtomicRef{T}
     AtomicRef{T}(x) where {T} = new{T}(convert(T, x))
 end
 
-mutable struct StableTask{T}
-    const t::Task
+struct StableTask{T}
+    t::Task
     ret::AtomicRef{T}
 end
 

--- a/src/internals.jl
+++ b/src/internals.jl
@@ -28,7 +28,10 @@ Base.schedule(t::StableTask) = (schedule(t.t); t)
 Base.schedule(t, val; error=false) = (schedule(t.t, val; error); t)
 
 """
-Similar to `Threads.@spawn` but type-stable. Creates a `Task` and schedules it to run on any available thread in the `:default` threadpool.
+    @spawn [:default|:interactive] expr
+
+Similar to `Threads.@spawn` but type-stable. Creates a `Task` and schedules it to run on any available
+thread in the specified threadpool (defaults to the `:default` threadpool).
 """
 macro spawn(args...)
     tp = QuoteNode(:default)
@@ -76,7 +79,7 @@ end
 
 """
 Similar to `StableTasks.@spawn` but creates a **sticky** `Task` and schedules it to run on the thread with the given id (`thrdid`).
-The task is guaranteed to stay on this thread (it won't migrate to another thread). 
+The task is guaranteed to stay on this thread (it won't migrate to another thread).
 """
 macro spawnat(thrdid, ex)
     letargs = _lift_one_interp!(ex)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,15 @@ using StableTasks: @spawn, @spawnat
     t = @eval @spawn inv([1 2 ; 3 4])
     @test inv([1 2 ; 3 4]) == @inferred fetch(t)
 
+    @test 2 == @inferred fetch(@spawn :interactive 1 + 1)
+    t = @eval @spawn :interactive inv([1 2 ; 3 4])
+    @test inv([1 2 ; 3 4]) == @inferred fetch(t)
+
+    s = :default
+    @test 2 == @inferred fetch(@spawn s 1 + 1)
+    t = @eval @spawn $(QuoteNode(s)) inv([1 2 ; 3 4])
+    @test inv([1 2 ; 3 4]) == @inferred fetch(t)
+
     @test 2 == @inferred fetch(@spawnat 1 1 + 1)
     t = @eval @spawnat 1 inv([1 2 ; 3 4])
     @test inv([1 2 ; 3 4]) == @inferred fetch(t)


### PR DESCRIPTION
Switch to using an `AtomicRef` for the returned data. @vchuravy told me that this is safer because "on a weak memory model you can reorder non atomic reads as you want". 