### PR TITLE
Be more robust when setting threadid of task

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:


### PR DESCRIPTION
This uses the same function Dagger uses to set the thread id of a task, it's a bit more robust than the simple ccall.  Reference to where Dagger uses this is in the docstring, but xref also [this Slack message](https://julialang.slack.com/archives/C6A044SQH/p1735474004227969?thread_ts=1735366488.848489&cid=C6A044SQH)