### PR TITLE
safer access to Julia's type inference

### DIFF
--- a/src/internals.jl
+++ b/src/internals.jl
@@ -2,14 +2,7 @@ module Internals
 
 import StableTasks: @spawn, @spawnat, @fetch, @fetchfrom, StableTask, AtomicRef
 
-# * use `Base.infer_return_type` in preference to `Core.Compiler.return_type`
-# * safe conservative fallback to `Any`, which is subtyped by each type
 if (
-    isdefined(Base, :infer_return_type) &&
-    applicable(Base.infer_return_type, identity, Tuple{})
-)
-    infer_return_type(@nospecialize f::Any) = Base.infer_return_type(f, Tuple{})
-elseif (
     (@isdefined Core) &&
     (Core isa Module) &&
     isdefined(Core, :Compiler) &&
@@ -19,6 +12,7 @@ elseif (
 )
     infer_return_type(@nospecialize f::Any) = Core.Compiler.return_type(f, Tuple{})
 else
+    # safe conservative fallback to `Any`, which is subtyped by each type
     infer_return_type(@nospecialize f::Any) = Any
 end
 


### PR DESCRIPTION
* Only access an implementation detail of Julia when it's available, falling back to `Any` as an accurate but possibly imprecise approximation of the return type.

Relevant links to the Julia code base:
* `Core.Compiler.return_type`:
    * https://github.com/JuliaLang/julia/blob/99a764750ef4e53214f2247d186ff4aac4f91983/Compiler/src/typeinfer.jl#L1416-L1434