### PR TITLE
Try to fix tests on nightly

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,12 @@
 using Test, StableTasks
 using StableTasks: @spawn, @spawnat, @fetch, @fetchfrom
 
+if isdefinded(Threads, :maxthreadid)
+    maxthreadid() = Threads.maxthreadid()
+else
+    maxthreadid() = Threads.nthreads()
+end
+
 @testset "Type stability" begin
     @test 2 == @inferred fetch(@spawn 1 + 1)
     t = @eval @spawn inv([1 2 ; 3 4])
@@ -16,7 +22,7 @@ using StableTasks: @spawn, @spawnat, @fetch, @fetchfrom
     @test inv([1 2 ; 3 4]) == @inferred fetch(t)
 
     @test 2 == @inferred fetch(@spawnat 1 1 + 1)
-    t = @eval @spawnat 1 inv([1 2 ; 3 4])
+    t = @eval @spawnat maxthreadid() inv([1 2 ; 3 4])
     @test inv([1 2 ; 3 4]) == @inferred fetch(t)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,10 @@
 using Test, StableTasks
 using StableTasks: @spawn, @spawnat, @fetch, @fetchfrom
 
-if isdefinded(Threads, :maxthreadid)
-    maxthreadid() = Threads.maxthreadid()
-else
-    maxthreadid() = Threads.nthreads()
-end
-
 @testset "Type stability" begin
+    t = @eval Threads.@spawn inv([1 2 ; 3 4])
+    fetch(t)
+    
     @test 2 == @inferred fetch(@spawn 1 + 1)
     t = @eval @spawn inv([1 2 ; 3 4])
     @test inv([1 2 ; 3 4]) == @inferred fetch(t)
@@ -22,8 +19,8 @@ end
     @test inv([1 2 ; 3 4]) == @inferred fetch(t)
 
     @test 2 == @inferred fetch(@spawnat 1 1 + 1)
-    t = @eval @spawnat maxthreadid() inv([1 2 ; 3 4])
-    @test inv([1 2 ; 3 4]) == @inferred fetch(t)
+    t = @eval @spawnat 1 1 + 1
+    @test 2 == @inferred fetch(t)
 end
 
 @testset "API funcs" begin


### PR DESCRIPTION
I think the failure was happening because nightly now has an interactive thread by default, and something weird occurred when trying to call `inv` on the interactive thread, I'm not totally sure. Checking by spawning that task on a regular thread